### PR TITLE
Revert project structure changes related to GitHub action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /node_modules
 /action/dist
 /action/node_modules
-index.js
 
 # Logs
 logs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,5 @@
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "esModuleInterop": true
-  },
-  "include": ["src/**/*", "test/**/*"]
+  }
 }


### PR DESCRIPTION
This reverts the non-`/action` project changes from d98116a, which had the unintentional side effect of changing the structure of the `dist` directory generated by `npm run build` and hence breaking the `npm run start:prod` task. These changes were introduced in order to allow us to put the GitHub action code into this repo, but as of ac84b07 that code no longer lives here any more, so we can safely revert these changes.