### PR TITLE
Add link to download crash report

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { TestCasesModule } from './testCases/testCases.module';
 import { FailuresModule } from './failures/failures.module';
 import { ReposModule } from './repos/repos.module';
 import { CrashReport } from './uploads/crashReport.entity';
+import { CrashReportsModule } from './crashReports/crashReports.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { CrashReport } from './uploads/crashReport.entity';
     TestCasesModule,
     FailuresModule,
     ReposModule,
+    CrashReportsModule,
   ],
   controllers: [AppController],
 })

--- a/src/crashReports/crashReports.controller.ts
+++ b/src/crashReports/crashReports.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param, Res, Header } from '@nestjs/common';
+import { CrashReportsService } from './crashReports.service';
+import { Response } from 'express';
+
+@Controller('repos/:owner/:name/crash_reports')
+export class CrashReportsController {
+  constructor(private readonly crashReportsService: CrashReportsService) {}
+
+  @Get(':id/download')
+  @Header('Content-Type', 'application/octet-stream')
+  async download(
+    @Param('id') id: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<string> {
+    const crashReport = await this.crashReportsService.find(id);
+
+    // Only repeat the extension of the original file if it’s one of our expected ones. Not really sure if this is of any use, but I don’t really like the idea of being tricked into giving somebody a malicious .dmg file or something.
+    const allowedExtensions = ['.crash', '.ips'];
+    const extensionToUse = allowedExtensions.find((allowedExtension) =>
+      crashReport.filename.endsWith(allowedExtension),
+    );
+
+    res.header(
+      'Content-Disposition',
+      `filename="crash_report_${crashReport.id}${extensionToUse ?? ''}"`,
+    );
+    return crashReport.data;
+  }
+}

--- a/src/crashReports/crashReports.module.ts
+++ b/src/crashReports/crashReports.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CrashReport } from '../uploads/crashReport.entity';
+import { CrashReportsController } from './crashReports.controller';
+import { CrashReportsService } from './crashReports.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CrashReport])],
+  controllers: [CrashReportsController],
+  providers: [CrashReportsService],
+})
+export class CrashReportsModule {}

--- a/src/crashReports/crashReports.service.ts
+++ b/src/crashReports/crashReports.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CrashReport } from '../uploads/crashReport.entity';
+
+@Injectable()
+export class CrashReportsService {
+  constructor(
+    @InjectRepository(CrashReport)
+    private crashReportsRepository: Repository<CrashReport>,
+  ) {}
+
+  async find(id: string): Promise<CrashReport> {
+    const results = await this.crashReportsRepository.find({
+      where: { id },
+    });
+    return results[0];
+  }
+}

--- a/src/failures/failure.viewModel.ts
+++ b/src/failures/failure.viewModel.ts
@@ -8,6 +8,7 @@ interface CrashReportViewModel {
   id: string;
   metadataDescriptionList: DescriptionListViewModel;
   report: string;
+  downloadHref: string;
 }
 
 export class FailureViewModel {
@@ -67,6 +68,10 @@ export class FailureViewModel {
         ],
       },
       report: crashReport.data,
+      downloadHref: ViewModelURLHelpers.hrefForCrashReportDownload(
+        crashReport.id,
+        this.repo,
+      ),
     }),
   );
 }

--- a/src/failures/failure.viewModel.ts
+++ b/src/failures/failure.viewModel.ts
@@ -5,7 +5,8 @@ import { UploadsFilter } from 'src/uploads/uploads.service';
 import { Repo } from 'src/repos/repo';
 
 interface CrashReportViewModel {
-  title: string;
+  id: string;
+  metadataDescriptionList: DescriptionListViewModel;
   report: string;
 }
 
@@ -52,7 +53,19 @@ export class FailureViewModel {
 
   readonly crashReports: CrashReportViewModel[] = this.failure.crashReports.map(
     (crashReport) => ({
-      title: crashReport.filename,
+      id: crashReport.id,
+      originalFilename: crashReport.filename,
+      metadataDescriptionList: {
+        items: [
+          {
+            term: 'Original filename',
+            description: {
+              type: 'text',
+              text: crashReport.filename,
+            },
+          },
+        ],
+      },
       report: crashReport.data,
     }),
   );

--- a/src/utils/viewModel/urlHelpers.ts
+++ b/src/utils/viewModel/urlHelpers.ts
@@ -64,6 +64,12 @@ export class ViewModelURLHelpers {
     return `/repos/${repoSlug(repo)}/failures/${encodeURIComponent(id)}`;
   }
 
+  static hrefForCrashReportDownload(id: string, repo: Repo) {
+    return `/repos/${repoSlug(repo)}/crash_reports/${encodeURIComponent(
+      id,
+    )}/download`;
+  }
+
   static queryComponentsForFilter(
     filter: UploadsFilter | null,
     { paramPrefix }: { paramPrefix: string | null } = { paramPrefix: null },

--- a/views/failures/details.njk
+++ b/views/failures/details.njk
@@ -11,7 +11,9 @@
 
     {% if viewModel.crashReports | length %}
         {% for crashReport in viewModel.crashReports %}
-            <h3>{{ crashReport.title }}</h3>
+            <h3>{{ crashReport.id }}</h3>
+
+            {{ descriptionList(crashReport.metadataDescriptionList) }}
 
             <pre>{{crashReport.report}}</pre>
         {% endfor %}

--- a/views/failures/details.njk
+++ b/views/failures/details.njk
@@ -11,7 +11,7 @@
 
     {% if viewModel.crashReports | length %}
         {% for crashReport in viewModel.crashReports %}
-            <h3>{{ crashReport.id }}</h3>
+            <h3>{{ crashReport.id }} (<a href="{{ crashReport.downloadHref }}">Download</a>)</h3>
 
             {{ descriptionList(crashReport.metadataDescriptionList) }}
 


### PR DESCRIPTION
## Description

This adds a link for downloading the original crash report data. This is useful for the new `.ips` format crash reports being uploaded as of https://github.com/ably/ably-cocoa/issues/1688, which are not very human-readable, but which macOS is capable of nicely formatting.

## Screenshot

<img width="1624" alt="Screenshot 2023-04-20 at 14 51 22" src="https://user-images.githubusercontent.com/53756884/233447848-65717785-9123-494d-8e81-0aaafbb9f119.png">
