### PR TITLE
Store URL of the GitHub job that performed upload

### DIFF
--- a/migration/1702576832109-AddJobUrlsToUploads.ts
+++ b/migration/1702576832109-AddJobUrlsToUploads.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddJobUrlsToUploads1702576832109 implements MigrationInterface {
+    name = 'AddJobUrlsToUploads1702576832109'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "uploads" ADD "github_job_api_url" character varying`);
+        await queryRunner.query(`ALTER TABLE "uploads" ADD "github_job_html_url" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "uploads" DROP COLUMN "github_job_html_url"`);
+        await queryRunner.query(`ALTER TABLE "uploads" DROP COLUMN "github_job_api_url"`);
+    }
+
+}

--- a/src/uploads/details.viewModel.ts
+++ b/src/uploads/details.viewModel.ts
@@ -163,6 +163,17 @@ export class UploadDetailsViewModel {
         description: { type: 'text', text: this.upload.githubJob },
       },
       {
+        term: 'GitHub job URL',
+        description:
+          this.upload.githubJobHtmlUrl == null
+            ? { type: 'text', text: 'Not known' }
+            : {
+                type: 'link',
+                text: this.upload.githubJobHtmlUrl,
+                href: this.upload.githubJobHtmlUrl,
+              },
+      },
+      {
         term: 'Loop iteration',
         description: { type: 'text', text: this.upload.iteration.toString() },
       },

--- a/src/uploads/postUploads.controller.ts
+++ b/src/uploads/postUploads.controller.ts
@@ -62,6 +62,14 @@ class CreateUploadDTO {
   @IsString()
   github_job!: string;
 
+  @ValidateIf((_, value: unknown) => value !== null && value !== undefined)
+  @IsString()
+  github_job_api_url!: string | null | undefined; /* backwards compatibility */
+
+  @ValidateIf((_, value: unknown) => value !== null && value !== undefined)
+  @IsString()
+  github_job_html_url!: string | null | undefined; /* backwards compatibility */
+
   @IsNumber()
   @Type(() => Number)
   iteration!: number;
@@ -141,6 +149,8 @@ export class PostUploadsController {
           githubBaseRef: body.github_base_ref,
           githubHeadRef: body.github_head_ref,
           githubJob: body.github_job,
+          githubJobApiUrl: body.github_job_api_url ?? null,
+          githubJobHtmlUrl: body.github_job_html_url ?? null,
           iteration: body.iteration,
         },
         crashReports,

--- a/src/uploads/upload.entity.ts
+++ b/src/uploads/upload.entity.ts
@@ -64,6 +64,14 @@ export class Upload {
   @Column({ name: 'github_job' })
   githubJob!: string;
 
+  // The URL of a GitHub REST API endpoint describing the job that performed this upload.
+  @Column({ name: 'github_job_api_url', nullable: true, type: 'varchar' })
+  githubJobApiUrl!: string | null;
+
+  // The URL of a GitHub web page describing the job that performed this upload.
+  @Column({ name: 'github_job_html_url', nullable: true, type: 'varchar' })
+  githubJobHtmlUrl!: string | null;
+
   // If running the tests multiple times inside a single CI job, this is the number of the current iteration.
   @Column()
   iteration!: number;


### PR DESCRIPTION
This adds new `github_job_html_url` and `github_job_api_url` parameters to the create upload endpoint, and saves them on the upload. It then adds a link to the `github_job_html_url` on the upload details page.

See https://github.com/ably/test-observability-action/pull/20 for an example of specifying these new parameters.

Here's an example of the UI looks now with some dummy data (see the new "GitHub job URL" field):

![image](https://github.com/ably/test-observability/assets/53756884/01637283-22fe-435c-b13b-f38e647e03e1)
