### PR TITLE
Sort uploads list by newest first

### DIFF
--- a/src/uploads/reports.service.ts
+++ b/src/uploads/reports.service.ts
@@ -98,7 +98,7 @@ ${
 GROUP BY
     uploads.id
 ORDER BY
-    uploads.created_at ASC`;
+    uploads.created_at DESC`;
 
     // See comment in subsequent method about learning how not to do this manually
     const results: Record<string, any>[] = await this.uploadsRepository.query(


### PR DESCRIPTION
We’re most frequently interested in recent uploads, not old ones.

Resolves #77.